### PR TITLE
Route for gfg profile data/rating

### DIFF
--- a/controller/ratingsController.js
+++ b/controller/ratingsController.js
@@ -153,4 +153,65 @@ const leetCodeRating = async (req, res) => {
         });
     }
 };
-module.exports = { atCoderRating, codechefRating, codeforcesRating, leetCodeRating };
+
+const GeeksForGeeksProfile = async (req, res) => {
+    const username = req.params.username;
+    const BASE_URL = `https://auth.geeksforgeeks.org/user/${username}/practice/`;
+
+    try {
+        const profilePage = await axios.get(BASE_URL);
+
+        if (profilePage.status !== 200) {
+            return res.status(503).json({
+                status: 'failure',
+                message: 'Profile Not Found'
+            });
+        }
+
+        const $ = cheerio.load(profilePage.data);
+
+        const additionalDetails = extractDetails($);
+        const codingScores = additionalDetails.coding_scores;
+
+        const response = {
+            status: "success",
+            handle: username,
+            over_all_coding_score: parseInt(codingScores.codingScore || 0, 10),
+            total_problem_solved: parseInt(codingScores.totalProblemsSolved || 0, 10),
+            monthly_coding_score: parseInt(codingScores.monthlyCodingScore || 0, 10),
+            over_all_article_published: parseInt(codingScores.articlesPublished || 0, 10)
+        };
+
+        res.status(200).send(response);
+    } catch (error) {
+        console.log('Error fetching GeeksForGeeks profile ->', error);
+        res.status(503).json({
+            status: 'failed',
+            message: 'Oops! Some error occurred'
+        });
+    }
+};
+
+const extractTextFromElements = ($, elements, elementKeys) => {
+    const result = {};
+    elements.each((index, element) => {
+        const innerText = $(element).text().trim();
+        result[elementKeys[index]] = innerText === '_ _' ? "" : innerText;
+    });
+    return result;
+};
+
+const extractDetails = ($) => {
+    const codingScoresByIndex = ["codingScore", "totalProblemsSolved", "monthlyCodingScore", "articlesPublished"];
+
+    let codingScores = $("span.score_card_value");
+    if (codingScores.length === 0) {
+        codingScores = $("div:contains('Coding Score')").nextAll("span");
+    }
+
+    return {
+        coding_scores: extractTextFromElements($, codingScores, codingScoresByIndex)
+    };
+};
+
+module.exports = { atCoderRating, codechefRating, codeforcesRating, leetCodeRating, GeeksForGeeksProfile };

--- a/router/ratingRouter.js
+++ b/router/ratingRouter.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const {atCoderRating, codechefRating,codeforcesRating,leetCodeRating} = require('../controller/ratingsController')
+const {atCoderRating, codechefRating,codeforcesRating,leetCodeRating, GeeksForGeeksProfile} = require('../controller/ratingsController')
 
 const ratingRouter = express.Router();
 
@@ -7,5 +7,6 @@ ratingRouter.get('/code_chef/:username', codechefRating)
 ratingRouter.get('/codeforces/:users',codeforcesRating)
 ratingRouter.get('/at_coder/:username',atCoderRating)
 ratingRouter.get('/leet_code/:username',leetCodeRating)
+ratingRouter.get('/geeks_for_geeks/:username',GeeksForGeeksProfile)
 
 module.exports=ratingRouter


### PR DESCRIPTION
This commit fixes #12 : Expose route for gfg profile data

Approach: We fetch the html content of the GeeksforGeeks user profile page using an HTTP GET request. We then uses Cheerio to parse the HTML content and navigate to extract required information. We extract the required data and structure it into a JSON response format and send it back to the client.

This is the final result when I tested on local host:

![image](https://github.com/Yash-Parsana/CrazyCoderServerlessApi/assets/111494403/f6a8e0ae-280e-4d21-af33-816df814d286)

I have made one major change to scheduleController.js in order to add the GeeksForGeeksProfile function and I've made minor changes elsewhere too ensure the route works. 

![image](https://github.com/Yash-Parsana/CrazyCoderServerlessApi/assets/111494403/81ebc9cc-12c5-4ca1-86a5-db1fd13a503b)
